### PR TITLE
GH-11# Improved CLI for check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check `dtl_hunter -h` for help, including a list of commands and flags avaiable.
 ### Global Options
 
 - `-e` | `--environment` : The Datalake API environment. Default to production. Possible values are `prod`, `preprod`
-- `-v` | `--version` :  Prints the installed version.
+- `-V` | `--version` :  Prints the installed version.
 - `-h` | `--help` : Prints the help message.
 
 ## Create command
@@ -64,11 +64,13 @@ Matched values can also be looked up on Datalake using the `-l` flag with the pa
 
 Multiple bloom filters and query hashes can be provided on a single check.
 
-The output will be saved to in a csv using the following format:
+The output will printed to the stdout using the following format:
 
 ```(csv)
 matching_value,bloom_filename
 ```
+
+The output can be saved into a file using the `-o` flag and providing the path to the file.
 
 When a query hash is provided, it will be used as the name of the bloom filter in the csv file.
 
@@ -89,3 +91,5 @@ dtl_hunter check -i input.txt -o output.csv -b subfolder/ip.bloom -b very_danger
 - `-i` | `--input` : Path to file containing the value to check, one value per line.
 - `-l` | `--lookup` : Path to the file in which Lookup matched values should be written.
 - `-o` | `--output` : Path to file to which the list of matching inputs will be pushed to as a csv file.
+- `--quiet` : Silence the output of matched value to the stdout.
+- `--no-header` : Remove the header from the CSV file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,27 +16,30 @@ pub fn read_input_file(path: &PathBuf) -> Result<Vec<String>, io::Error> {
     let reader: BufReader<File> = BufReader::new(file);
     let mut input: Vec<String> = Vec::new();
     for line in reader.lines() {
-        match line {
-            Ok(l) => input.push(l),
-            Err(e) => return Err(e),
-        }
+        input.push(line?);
     }
     Ok(input)
 }
 
-pub fn write_csv(matches: HashMap<String, Vec<String>>, output: &PathBuf) -> Result<(), String> {
+pub fn write_csv(
+    matches: &HashMap<String, Vec<String>>,
+    output: &PathBuf,
+    no_header: &bool,
+) -> Result<(), String> {
     let mut writer: csv::Writer<File> = match csv::Writer::from_path(&output) {
         Ok(writer) => writer,
         Err(e) => return Err(format!("{}: {}", &output.display(), e)),
     };
-    match writer.write_record(&["matching_value", "bloom_filename"]) {
-        // write the csv header
-        Ok(()) => (),
-        Err(e) => return Err(format!("{}: {}", &output.display(), e)),
-    };
+    if !no_header {
+        match writer.write_record(&["matching_value", "bloom_filename"]) {
+            // write the csv header
+            Ok(()) => (),
+            Err(e) => return Err(format!("{}: {}", &output.display(), e)),
+        };
+    }
     for (filename, values) in matches {
         for val in values {
-            match writer.write_record(&[val, filename.clone()]) {
+            match writer.write_record(&[val, filename]) {
                 Ok(()) => (),
                 Err(e) => return Err(format!("{}: {}", &output.display(), e)),
             }
@@ -110,6 +113,18 @@ pub fn create_bloom_from_file(
 
     let bloom: Bloom<String> = create_bloom(input, size, positive_rate);
     Ok(bloom)
+}
+
+pub fn get_bloom_from_path(
+    bloom_paths: &Vec<PathBuf>,
+) -> Result<HashMap<String, Bloom<String>>, String> {
+    let mut blooms: HashMap<String, Bloom<String>> = HashMap::new();
+    for path in bloom_paths {
+        let filename = get_filename_from_path(path)?;
+        let bloom = deserialize_bloom(path)?;
+        blooms.insert(filename, bloom);
+    }
+    Ok(blooms)
 }
 
 pub fn create_bloom_from_queryhash() {}


### PR DESCRIPTION
- Changed default behavior to printing the matched values in the stdout, `output` flag is now optional 
- Added an optional `--quiet` flag to remove printing to the stdout.
- Changed printing of status message to logging with appropriate logging level
- Added an optional `--no-header` flag to remove the header from the CSV file.