### PR TITLE
v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtl_hunter"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1.0.143"
 ron = "0.8.0"
 colored = "2.0.0"
 csv = "1.1.6"
-ocd_datalake_rs = "0.1.1"
+ocd_datalake_rs = "0.1.2"
 rpassword = "7.0.0"
 spinners = "4.1.0"
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 #[clap(
     name = "Datalake Hunter",
     author = "orangecyberdefense.com",
-    version = "0.1.0",
+    version = "0.1.1",
     about = "Allow to mass check data from datalake using bloom filters.",
     long_about = None
 )]


### PR DESCRIPTION
updated `ocd_datalake_rs` version to fix timeout on large queryhashes from datalake.