### PR TITLE
MRTI-5098 # Added better error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtl_hunter"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -14,7 +14,7 @@ serde = "1.0.143"
 ron = "0.8.0"
 colored = "2.0.0"
 csv = "1.1.6"
-ocd_datalake_rs = "0.1.2"
+ocd_datalake_rs = "0.2.0"
 rpassword = "7.0.0"
 spinners = "4.1.0"
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,12 +40,12 @@ pub fn write_csv(
     output: &PathBuf,
     no_header: &bool,
 ) -> Result<(), String> {
-    let mut writer: Writer<File> = match Writer::from_path(&output) {
+    let mut writer: Writer<File> = match Writer::from_path(output) {
         Ok(writer) => writer,
         Err(e) => return Err(format!("{}: {}", &output.display(), e)),
     };
     if !no_header {
-        match writer.write_record(&["matching_value", "bloom_filename"]) {
+        match writer.write_record(["matching_value", "bloom_filename"]) {
             // write the csv header
             Ok(()) => (),
             Err(e) => return Err(format!("{}: {}", &output.display(), e)),
@@ -53,7 +53,7 @@ pub fn write_csv(
     }
     for (filename, values) in matches {
         for val in values {
-            match writer.write_record(&[val, filename]) {
+            match writer.write_record([val, filename]) {
                 Ok(()) => (),
                 Err(e) => return Err(format!("{}: {}", &output.display(), e)),
             }
@@ -68,7 +68,7 @@ pub fn write_csv(
 }
 
 pub fn write_file(output_path: &PathBuf, content: String) -> Result<(), String> {
-    let mut output_file: File = match File::create(&output_path) {
+    let mut output_file: File = match File::create(output_path) {
         Ok(output_file) => output_file,
         Err(e) => return Err(format!("{}: {}", output_path.display(), e)),
     };


### PR DESCRIPTION
When a user that did not have the privileges to do a bulk search, the error message was not informing the user of the issue, only that the response was not as expected.
The error logging now print the api response with the summary.